### PR TITLE
Audio: Hal: Specify AIDL version to V1

### DIFF
--- a/hal/Android.mk
+++ b/hal/Android.mk
@@ -372,7 +372,7 @@ endif
 
 LOCAL_SHARED_LIBRARIES += libbase libhidlbase libutils android.hardware.power@1.2 liblog
 
-LOCAL_SHARED_LIBRARIES += android.hardware.power-ndk_platform
+LOCAL_SHARED_LIBRARIES += android.hardware.power-V1-ndk_platform
 LOCAL_SHARED_LIBRARIES += libbinder_ndk
 
 LOCAL_SRC_FILES += audio_perf.cpp


### PR DESCRIPTION
- Fixes  
FAILED: ninja: '/*/*/*/out/target/product/whyred/obj_arm/SHARED_LIBRARIES/android.hardware.power-ndk_platform_intermediates/android.hardware.power-ndk_platform.so.toc', needed by '/*/*/*/out/target/product/whyred/obj_arm/SHARED_LIBRARIES/audio.primary.sdm660_intermediates/LINKED/audio.primary.sdm660.so', missing and no known rule to make it